### PR TITLE
Fix dependency name (`uglify` -> `uglify-js`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+public/bundle.js

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ecstatic": "~0.8.0",
     "react": "~0.13.3",
     "reactify": "^1.1.1",
-    "uglify": "~0.1.5",
+    "uglify-js": "^2.4.24",
     "watchify": "^3.2.3"
   },
   "license": "public domain"


### PR DESCRIPTION
This makes `npm run build` work correctly.

Right now the command does not work:
```
macbook:react-starter luigi$ npm run build

> react-starter@ build /Users/luigi/Desktop/repos/react-starter
> NODE_ENV=production browserify main.js | uglifyjs -cm > public/bundle.js

sh: uglifyjs: command not found
```